### PR TITLE
Bugfix for array underflow

### DIFF
--- a/tfjs.js
+++ b/tfjs.js
@@ -69,6 +69,7 @@ module.exports = function (RED) {
                 if (m.payload[i].score < m.scoreThreshold) {
                     m.payload.splice(i,1);
                     i = i - 1;
+                    continue;
                 }
                 if (m.payload[i].hasOwnProperty("class")) {
                     m.classes[m.payload[i].class] = (m.classes[m.payload[i].class] || 0 ) + 1;


### PR DESCRIPTION
Hi @dceejay 

Found an obscure array underflow bug in the tfjs-coco-ssd node.  Great node btw. :)

The bug manifests when there is only 1 detection in m.payload and it does not meet the confidence threshold.  

The payload array is spliced to remove the item, which leaves an empty array, and then variable `i` is reduced from 0 to -1.  Without the continue statement I added, the loop continues on line 73 where it attempt to access an element at position -1 and it throws a fatal error:

```
TypeError: Cannot read properties of undefined (reading 'hasOwnProperty')
at reco (/home/clarkd/.node-red/node_modules/node-red-contrib-tfjs-coco-ssd/tfjs.js:73:34)
```

By adding the continue statement, the loop will increment i from -1 back to 0, and then fail the length test, and pass executation after the loop.  This should also work if there are multiple detections in the payload array, and the last one does not meet the confidence threshold.

I've only tested it briefly on my install, but I think the logic is correct.

D.